### PR TITLE
Update color thief naming conventions.

### DIFF
--- a/class.media-extractor.php
+++ b/class.media-extractor.php
@@ -512,8 +512,8 @@ class Jetpack_Media_Meta_Extractor {
 		if ( ! class_exists( 'Jetpack_Color' ) ) {
 			jetpack_require_lib( 'class.color' ); // We need Jetpack_Color, we need it bad
 		}
-		if ( ! class_exists( 'ColorThief' ) ) {
-			jetpack_require_lib( 'ColorThief' ); // ColorThief is lightweight advanced MMCQ library that gives
+		if ( ! class_exists( 'Jetpack_ColorThief' ) ) {
+			jetpack_require_lib( 'class.color-thief.php' ); // ColorThief is lightweight advanced MMCQ library that gives
 			                                     // best results in an area of color quantization
 		}
 
@@ -523,7 +523,7 @@ class Jetpack_Media_Meta_Extractor {
 		// small images compared to the large ones.
 		$max_tests     = 1500;
 		$skip_constant = ceil( sqrt( ( $width * $height ) / $max_tests ) );
-		$palette       = ColorThief::getPalette( $image_obj, $num_colors, $skip_constant );
+		$palette       = Jetpack_ColorThief::getPalette( $image_obj, $num_colors, $skip_constant );
 
 		// Until disproved, we assume this is a grayscale image
 		$is_grayscale  = true;


### PR DESCRIPTION
I added prefixes with Jetpack_ and Jetpack_CT_ so the namespace stays unique to JP. Seemed like a small self contained change to just do a pull request on.

Not 100% sure I didn't break anything as I haven't got any of our tests going against this yet. :)
